### PR TITLE
default index on status added on nosql models

### DIFF
--- a/cmd/generate/stubs/model.stub
+++ b/cmd/generate/stubs/model.stub
@@ -16,6 +16,20 @@ type {{TitleName}} struct {
     UpdatedAt time.Time          `json:"updated_at,omitempty" bson:"updated_at"`
 }
 
+func createIndexes() {
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{"status", -1}},
+			Options: options.Index().SetName("status_index"),
+		},
+	}
+	_, err := {{TitleName}}Collection.Indexes().CreateMany(context.Background(), indexes)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func {{TitleName}}Setup() {
 	{{TitleName}}Collection = artifact.Mongo.Collection("{{PluralLowerName}}")
+	createIndexes()
 }


### PR DESCRIPTION
# Add Index Creation for `NoSQL` Collections

## Description

This pull request introduces the creation of an index on the `{{TitleName}}` collection to improve query performance based on default `status` field. Devs may add up their requires fields on that. 

### Key Changes:

- **Index Creation:**
  - Added a new index on the `status` field in descending order (`-1`).
  - The `createIndexes` function is responsible for creating the index when the `{{TitleName}}Setup` function is called.

- **Setup Function:**
  - Introduced the `{{TitleName}}Setup` function which:
    - Initializes the `{{TitleName}}Collection` by referencing the `{{PluralLowerName}}` collection from the MongoDB database.
    - Calls the `createIndexes` function to ensure the index is created during the setup process.

### Benefits:
- **Performance Improvement:** The addition of this index is expected to significantly improve query performance, especially for operations filtering by the `status` field.

### Testing:
- This change should be tested by executing queries on the `{{TitleName}}` collection to ensure that the index is being utilized as expected.
- Ensure that the index creation process does not introduce any errors or performance regressions during the collection setup.

---

Please review the changes and provide feedback.
